### PR TITLE
Update Calculation of v/y-pairity for eip 1559 and 2390

### DIFF
--- a/src/transactions/EIP1559.mo
+++ b/src/transactions/EIP1559.mo
@@ -116,24 +116,23 @@ module EIP1559 {
             case (#err(msg)) {
                 return #err(msg);
             };
+            //to whom it may concern. 0 is to be rlp encoded as 80 or 'Empty' where as 1 gets encoded as 8101. Don't ask me why. It took me 5 hours to figure out. If you try to put "00" here it will out put "00" and you'll get errors that v can't start with 00
+            //to find the y parity bit from a compressed key you can take the first byte and subtract 2.  see https://bitcoin.stackexchange.com/questions/96848/in-compressed-public-keys-is-the-2-or-3-the-parity-or-the-sign
+            //I believe that this code assumes a compressed key as the previous call to the Helper.getRecoveryId checked for 33 bytes
             case (#ok(message)) {
-                switch(Helper.getRecoveryId(message, signature, publicKey, ctx)) {
-                    case (#err(msg)) {
-                        return #err(msg);
-                    };
-                    case (#ok(recovery_id)) {
-                        let v = if(recovery_id == 0) "" else "01";
-
-                        return #ok({
-                            tx
-                            with
-                            v = v;
-                            r = r;
-                            s = s;
-                        });
-                    };
+                let v = if(publicKey[0] == 2) {
+                  ""
+                } else {
+                  "01"
                 };
             };
+            return #ok({
+                tx
+                with
+                v = v;
+                r = r;
+                s = s;
+            });
         };
     };
 

--- a/src/transactions/EIP1559.mo
+++ b/src/transactions/EIP1559.mo
@@ -119,6 +119,7 @@ module EIP1559 {
             //to whom it may concern. 0 is to be rlp encoded as 80 or 'Empty' where as 1 gets encoded as 8101. Don't ask me why. It took me 5 hours to figure out. If you try to put "00" here it will out put "00" and you'll get errors that v can't start with 00
             //to find the y parity bit from a compressed key you can take the first byte and subtract 2.  see https://bitcoin.stackexchange.com/questions/96848/in-compressed-public-keys-is-the-2-or-3-the-parity-or-the-sign
             //I believe that this code assumes a compressed key as the previous call to the Helper.getRecoveryId checked for 33 bytes
+            //This looks to apply to eip 1559 and 2930 transactions, but not to legacy which still need chain id encoded into them.
             case (#ok(message)) {
                 let v = if(publicKey[0] == 2) {
                   ""

--- a/src/transactions/EIP1559.mo
+++ b/src/transactions/EIP1559.mo
@@ -126,14 +126,15 @@ module EIP1559 {
                 } else {
                   "01"
                 };
+                return #ok({
+                    tx
+                    with
+                    v = v;
+                    r = r;
+                    s = s;
+                });
             };
-            return #ok({
-                tx
-                with
-                v = v;
-                r = r;
-                s = s;
-            });
+            
         };
     };
 

--- a/src/transactions/EIP2930.mo
+++ b/src/transactions/EIP2930.mo
@@ -118,20 +118,20 @@ module EIP2930 {
                 //to find the y parity bit from a compressed key you can take the first byte and subtract 2.  see https://bitcoin.stackexchange.com/questions/96848/in-compressed-public-keys-is-the-2-or-3-the-parity-or-the-sign
                 //I believe that this code assumes a compressed key as the previous call to the Helper.getRecoveryId checked for 33 bytes
                 //This looks to apply to eip 1559 and 2930 transactions, but not to legacy which still need chain id encoded into them.
-                case (#ok(message)) {
-                    let v = if(publicKey[0] == 2) {
-                      ""
-                    } else {
-                      "01"
-                    };
-                    return #ok({
-                        tx
-                        with
-                        v = v;
-                        r = r;
-                        s = s;
-                    });
+        
+                let v = if(publicKey[0] == 2) {
+                  ""
+                } else {
+                  "01"
                 };
+                return #ok({
+                    tx
+                    with
+                    v = v;
+                    r = r;
+                    s = s;
+                });
+                
             };
         };
     };

--- a/src/transactions/EIP2930.mo
+++ b/src/transactions/EIP2930.mo
@@ -124,6 +124,13 @@ module EIP2930 {
                     } else {
                       "01"
                     };
+                    return #ok({
+                        tx
+                        with
+                        v = v;
+                        r = r;
+                        s = s;
+                    });
                 };
             };
         };

--- a/src/transactions/EIP2930.mo
+++ b/src/transactions/EIP2930.mo
@@ -114,20 +114,15 @@ module EIP2930 {
                 return #err(msg);
             };
             case (#ok(message)) {
-                switch(Helper.getRecoveryId(message, signature, publicKey, ctx)) {
-                    case (#err(msg)) {
-                        return #err(msg);
-                    };
-                    case (#ok(recovery_id)) {
-                        let v = if(recovery_id == 0) "" else "01";
-
-                        return #ok({
-                            tx
-                            with
-                            v = v;
-                            r = r;
-                            s = s;
-                        });
+                //to whom it may concern. 0 is to be rlp encoded as 80 or 'Empty' where as 1 gets encoded as 8101. Don't ask me why. It took me 5 hours to figure out. If you try to put "00" here it will out put "00" and you'll get errors that v can't start with 00
+                //to find the y parity bit from a compressed key you can take the first byte and subtract 2.  see https://bitcoin.stackexchange.com/questions/96848/in-compressed-public-keys-is-the-2-or-3-the-parity-or-the-sign
+                //I believe that this code assumes a compressed key as the previous call to the Helper.getRecoveryId checked for 33 bytes
+                //This looks to apply to eip 1559 and 2930 transactions, but not to legacy which still need chain id encoded into them.
+                case (#ok(message)) {
+                    let v = if(publicKey[0] == 2) {
+                      ""
+                    } else {
+                      "01"
                     };
                 };
             };


### PR DESCRIPTION
See https://bitcoin.stackexchange.com/questions/96848/in-compressed-public-keys-is-the-2-or-3-the-parity-or-the-sign

If you have the compressed public key you can just look at the first byte to figure out y-parity.

This was failing for 0 parity because the signature was not recovering correctly and I was getting an #err("Not found") from Helper.getRecoveryId.

This seems to fix the glitch.